### PR TITLE
Support for limit and order_by

### DIFF
--- a/bamboo/controllers/datasets.py
+++ b/bamboo/controllers/datasets.py
@@ -36,7 +36,7 @@ class Datasets(AbstractController):
         return self.dump_or_error(result, 'id not found')
 
     def GET(self, dataset_id, mode=False, query=None, select=None,
-            group=None):
+            group=None, limit=None, order_by=None):
         """
         Based on *mode* perform different operations on the dataset specified
         by *dataset_id*.
@@ -74,11 +74,13 @@ class Datasets(AbstractController):
                     else:
                         if select == self.SELECT_ALL_FOR_SUMMARY:
                             select = None
-                        result = dataset.summarize(
-                            dataset, query, select, group)
+                        result = dataset.summarize(dataset, query, select, 
+                                                   group, limit=limit,
+                                                   order_by=order_by)
                 elif mode is False:
                     return dframe_to_json(
-                        dataset.dframe(query=query, select=select))
+                        dataset.dframe(query=query, select=select,
+                                       limit=limit, order_by=order_by))
                 else:
                     error = 'unsupported API call'
         except (ColumnTypeError, JSONError) as e:

--- a/bamboo/controllers/datasets.py
+++ b/bamboo/controllers/datasets.py
@@ -36,7 +36,7 @@ class Datasets(AbstractController):
         return self.dump_or_error(result, 'id not found')
 
     def GET(self, dataset_id, mode=False, query=None, select=None,
-            group=None, limit=None, order_by=None):
+            group=None, limit=0, order_by=None):
         """
         Based on *mode* perform different operations on the dataset specified
         by *dataset_id*.
@@ -74,7 +74,7 @@ class Datasets(AbstractController):
                     else:
                         if select == self.SELECT_ALL_FOR_SUMMARY:
                             select = None
-                        result = dataset.summarize(dataset, query, select, 
+                        result = dataset.summarize(dataset, query, select,
                                                    group, limit=limit,
                                                    order_by=order_by)
                 elif mode is False:

--- a/bamboo/models/abstract_model.py
+++ b/bamboo/models/abstract_model.py
@@ -22,8 +22,9 @@ class AbstractModel(object):
 
     @classmethod
     def find(cls, query, select=None, as_dict=False,
-             limit=None, order_by=None):
-        """ Interface to mongo's find()
+             limit=0, order_by=None):
+        """
+        Interface to mongo's find()
 
         order_by: sort resulting rows according to a column value (ASC or DESC)
             Examples:   order_by='mycolumn'
@@ -32,7 +33,6 @@ class AbstractModel(object):
         limit: apply a limit on the number of rows returned.
             limit is applied AFTER ordering.
         """
-        records = cls.collection.find(query, select)
 
         # apply ORDER BY
         # Usage:
@@ -42,14 +42,10 @@ class AbstractModel(object):
                 sort_dir, field = -1 if order_by[0] == '-' else 1, order_by[1:]
             else:
                 sort_dir, field = 1, order_by
-            records = records.sort(field, sort_dir)
+            order_by = [(field, sort_dir)]
 
-        # apply LIMIT
-        # limit is applied AFTER order_by as we assume people would want
-        # to limit the overall data.
-        # It's less efficient that sorting a limited subset of data obvsl.
-        if limit:
-            records = records.limit(limit)
+        records = cls.collection.find(
+            query, select, sort=order_by, limit=limit)
 
         return [record for record in records] if as_dict else [
             cls(record) for record in records

--- a/bamboo/models/dataset.py
+++ b/bamboo/models/dataset.py
@@ -75,7 +75,7 @@ class Dataset(AbstractModel):
         return [self.find_one(_id) for _id in self.merged_dataset_ids]
 
     def dframe(self, query=None, select=None, keep_parent_ids=False,
-               limit=None, order_by=None):
+               limit=0, order_by=None):
         observations = self.observations(query=query, select=select,
                                          limit=limit, order_by=order_by)
         dframe = mongo_to_df(observations)
@@ -119,7 +119,7 @@ class Dataset(AbstractModel):
 
     @task
     def summarize(self, query=None, select=None,
-                  group_str=None, limit=None, order_by=None):
+                  group_str=None, limit=0, order_by=None):
         """
         Return a summary for the rows/values filtered by *query* and *select*
         and grouped by *group_str* or the overall summary if no group is
@@ -192,7 +192,7 @@ class Dataset(AbstractModel):
             (column_attrs[self.LABEL], reserve_encoded(column_name)) for
             (column_name, column_attrs) in self.schema.items()])
 
-    def observations(self, query=None, select=None, limit=None, order_by=None):
+    def observations(self, query=None, select=None, limit=0, order_by=None):
         return Observation.find(self, query, select,
                                 limit=limit, order_by=order_by)
 

--- a/bamboo/models/dataset.py
+++ b/bamboo/models/dataset.py
@@ -74,8 +74,10 @@ class Dataset(AbstractModel):
     def merged_datasets(self):
         return [self.find_one(_id) for _id in self.merged_dataset_ids]
 
-    def dframe(self, query=None, select=None, keep_parent_ids=False):
-        observations = self.observations(query=query, select=select)
+    def dframe(self, query=None, select=None, keep_parent_ids=False,
+               limit=None, order_by=None):
+        observations = self.observations(query=query, select=select,
+                                         limit=limit, order_by=order_by)
         dframe = mongo_to_df(observations)
         dframe.remove_bamboo_reserved_keys(keep_parent_ids)
         return dframe
@@ -116,7 +118,8 @@ class Dataset(AbstractModel):
         Observation.delete_all(self)
 
     @task
-    def summarize(self, query=None, select=None, group_str=None):
+    def summarize(self, query=None, select=None,
+                  group_str=None, limit=None, order_by=None):
         """
         Return a summary for the rows/values filtered by *query* and *select*
         and grouped by *group_str* or the overall summary if no group is
@@ -138,7 +141,8 @@ class Dataset(AbstractModel):
             select = json.dumps(select)
 
         # narrow list of observations via query/select
-        dframe = self.dframe(query=query, select=select)
+        dframe = self.dframe(query=query, select=select,
+                             limit=limit, order_by=order_by)
 
         return summarize(self, dframe, groups, group_str, query or select)
 
@@ -188,8 +192,9 @@ class Dataset(AbstractModel):
             (column_attrs[self.LABEL], reserve_encoded(column_name)) for
             (column_name, column_attrs) in self.schema.items()])
 
-    def observations(self, query=None, select=None):
-        return Observation.find(self, query, select)
+    def observations(self, query=None, select=None, limit=None, order_by=None):
+        return Observation.find(self, query, select,
+                                limit=limit, order_by=order_by)
 
     def calculations(self):
         return Calculation.find(self)

--- a/bamboo/models/observation.py
+++ b/bamboo/models/observation.py
@@ -25,7 +25,7 @@ class Observation(AbstractModel):
         cls.collection.remove(query, safe=True)
 
     @classmethod
-    def find(cls, dataset, query=None, select=None, limit=None, order_by=None):
+    def find(cls, dataset, query=None, select=None, limit=0, order_by=None):
         """
         Try to parse query if exists, then get all rows for ID matching query,
         or if no query all.  Decode rows from mongo and return.

--- a/bamboo/models/observation.py
+++ b/bamboo/models/observation.py
@@ -2,7 +2,6 @@ import json
 
 from bson import json_util
 
-from bamboo.config.db import Database
 from bamboo.config.settings import DB_BATCH_SIZE
 from bamboo.core.frame import DATASET_OBSERVATION_ID
 from bamboo.lib.datetools import parse_timestamp_query
@@ -26,10 +25,17 @@ class Observation(AbstractModel):
         cls.collection.remove(query, safe=True)
 
     @classmethod
-    def find(cls, dataset, query=None, select=None):
+    def find(cls, dataset, query=None, select=None, limit=None, order_by=None):
         """
         Try to parse query if exists, then get all rows for ID matching query,
         or if no query all.  Decode rows from mongo and return.
+
+        order_by: sort resulting rows according to a column value (ASC or DESC)
+            Examples:   order_by='mycolumn'
+                        order_by='-mycolumn'
+
+        limit: apply a limit on the number of rows returned.
+            limit is applied AFTER ordering.
         """
         try:
             query = (query and json.loads(
@@ -46,9 +52,8 @@ class Observation(AbstractModel):
                 raise JSONError('cannot decode select: %s' % e.__str__())
 
         query[DATASET_OBSERVATION_ID] = dataset.dataset_observation_id
-        rows = super(cls, cls).find(query, select, as_dict=True)
-
-        return rows
+        return super(cls, cls).find(query, select, as_dict=True,
+                                    limit=limit, order_by=order_by)
 
     def save(self, dframe, dataset):
         """

--- a/bamboo/tests/controllers/test_datasets.py
+++ b/bamboo/tests/controllers/test_datasets.py
@@ -361,6 +361,30 @@ class TestDatasets(TestAbstractDatasets):
         self._test_get_with_query_or_select('{"rating": "delectible"}',
                                             num_results=11)
 
+    def test_GET_with_query_limit_order_by(self):
+
+        def get_results(query='{}', select=None, limit=None, order_by=None):
+            self._post_file()
+            return json.loads(self.controller.GET(self.dataset_id,
+                                                 query=query,
+                                                 select=select,
+                                                 limit=limit,
+                                                 order_by=order_by))
+
+        # test the limit
+        limit = 4
+        results = get_results(limit=limit)
+        self.assertEqual(len(results), limit)
+
+        # test the order_by
+        limit = 1
+        results = get_results(limit=limit, order_by='rating')
+        self.assertEqual(results[0].get('rating'), 'delectible')
+
+        limit = 1
+        results = get_results(limit=limit, order_by='-rating')
+        self.assertEqual(results[0].get('rating'), 'epic_eat')
+
     def test_GET_with_bad_query(self):
         self._post_file()
         results = json.loads(self.controller.GET(self.dataset_id,

--- a/bamboo/tests/controllers/test_datasets.py
+++ b/bamboo/tests/controllers/test_datasets.py
@@ -366,10 +366,10 @@ class TestDatasets(TestAbstractDatasets):
         def get_results(query='{}', select=None, limit=None, order_by=None):
             self._post_file()
             return json.loads(self.controller.GET(self.dataset_id,
-                                                 query=query,
-                                                 select=select,
-                                                 limit=limit,
-                                                 order_by=order_by))
+                                                  query=query,
+                                                  select=select,
+                                                  limit=limit,
+                                                  order_by=order_by))
 
         # test the limit
         limit = 4


### PR DESCRIPTION
Guys,

This PR adds support for two new parameters on datasets requests:
- **order_by**: orders the results by the column specified.
  Syntax: order_by='rating' or order_by='-rating'
- **limit**: restricts the results to that number of rows.

Beware that the limit is performed **after** the order_by.

Also, this has been added to _Observations_ only. I don't see the immediate need for it on datasets.

I've added a test for both but I did not change the documentation.

Tests passes on my machine but travis seems to have difficulties installing the dependencies.
