### PR TITLE
[DO NOT MERGE] Fixes 500 Error on overlapping columns during join

### DIFF
--- a/bamboo/controllers/datasets.py
+++ b/bamboo/controllers/datasets.py
@@ -372,7 +372,8 @@ class Datasets(AbstractController):
                 }
 
         return self._safe_get_and_call(
-            dataset_id, action, exceptions=(KeyError, NonUniqueJoinError))
+            dataset_id, action, exceptions=(KeyError,
+                                            NonUniqueJoinError, Exception))
 
     def resample(self, dataset_id, date_column, interval, how='mean',
                  query={}, format=None):


### PR DESCRIPTION
from @rgaudin 

When joining datasets which have overlapping columns, bamboo raises a 500 error.
This fixes it but it seems _way_ too permissive (catches all `Exception`) so please take this more as a bug report than a patch.

Unfortunately, the root exception is not specific and resides in pandas:

```
  File "/Volumes/data/src/envs/bamboo/lib/python2.7/site-packages/pandas/core/internals.py", line 1197, in _maybe_rename_join
    raise Exception('columns overlap: %s' % to_rename)
Exception: columns overlap: Index([_submission_time, _uuid, meta_instanceid], dtype=object)
```
