### PR TITLE
Mongodb "$in" queries not working

### DIFF
--- a/bamboo/lib/utils.py
+++ b/bamboo/lib/utils.py
@@ -45,6 +45,8 @@ def replace_keys(original, mapping):
 
     :returns: Original with keys replaced via mapping.
     """
+    if not type(original) in (dict, list):
+        return original
     return original and {
         mapping.get(k, k): {
             dict: lambda: replace_keys(v, mapping),

--- a/bamboo/lib/utils.py
+++ b/bamboo/lib/utils.py
@@ -45,9 +45,7 @@ def replace_keys(original, mapping):
 
     :returns: Original with keys replaced via mapping.
     """
-    if not type(original) in (dict, list):
-        return original
-    return original and {
+    return original if not type(original) in (dict, list) else {
         mapping.get(k, k): {
             dict: lambda: replace_keys(v, mapping),
             list: lambda: [replace_keys(vi, mapping) for vi in v]


### PR DESCRIPTION
Mongo [$in queries](http://docs.mongodb.org/manual/reference/operator/in/) are not working anymore, failing inside `libs.utils.replace_keys` complaining that `unicode` does not have an `iteritems()`.

I must admit that the dict comprehension is a bit difficult to understand and _I might have missed it_, so please, read the patch carefully.

Though, I could fix the problem and `$in` queries are providing me expected results while passing tests.
