### PR TITLE
Failing import datasets with index

### DIFF
--- a/bamboo/core/frame.py
+++ b/bamboo/core/frame.py
@@ -45,7 +45,7 @@ class BambooFrame(DataFrame):
 
             self.rename(columns={'index': INDEX}, inplace=True)
 
-        return self.__class__(self)
+        return BambooFrame(self)
 
     def add_id_column(self, dataset_id):
         return self.add_constant_column(dataset_id, DATASET_ID) if not\


### PR DESCRIPTION
Currently, on my local setup, all new dataset creation fails.
I identified the cause down to the `add_index` method in `BambooFrame` which is called from `encode` in `Observation`.

In this method, you call `rename(inplace=True)` on the `BambooFrame` then returns a new `BambooFrame` from the result.

The problem is that the `rename()` seems to cast the object to a `pandas.core.frame.DataFrame` which is unsuitable to return as we are expecting a `BambooFrame`.

Please take a look at the trivial patch which might be improved.

I wonder if the problem is due to a particular version of pandas-------- ahhhh
Nevermind, I just found out that my _launch_bamboo_ script was calling the wrong virtualenv which used the old pandas `0.10.1` instead of `0.11`.
This works fine on `0.11`.

I'm leaving this open for you to deal with ;
