### PR TITLE
On observation (row) update and delete do not remove data

### DIFF
--- a/bamboo/core/operations.py
+++ b/bamboo/core/operations.py
@@ -1,12 +1,11 @@
 # future must be first
 from __future__ import division
-from datetime import datetime
 import operator
 
 import numpy as np
 from scipy.stats import percentileofscore
 
-from bamboo.lib.datetools import parse_date_to_unix_time,\
+from bamboo.lib.datetools import now, parse_date_to_unix_time,\
     parse_str_to_unix_time, safe_parse_date_to_unix_time
 from bamboo.lib.query_args import QueryArgs
 from bamboo.lib.utils import parse_float
@@ -294,7 +293,7 @@ class EvalToday(EvalTerm):
     """Class to produce te current date time."""
 
     def eval(self, row, dataset):
-        return parse_date_to_unix_time(datetime.now())
+        return parse_date_to_unix_time(now())
 
 
 class EvalPercentile(EvalFunction):

--- a/bamboo/lib/datetools.py
+++ b/bamboo/lib/datetools.py
@@ -68,6 +68,10 @@ def _convert_column_to_date(dframe, column):
         pass
 
 
+def now():
+    return datetime.now()
+
+
 def parse_date(x):
     try:
         return date_parse(x) if _is_potential_date(x) else x
@@ -83,13 +87,6 @@ def parse_date_to_unix_time(date):
     return timegm(date.utctimetuple())
 
 
-def safe_parse_date_to_unix_time(date):
-    if isinstance(date, datetime):
-        date = parse_date_to_unix_time(date)
-
-    return date
-
-
 def parse_timestamp_query(query, schema):
     """Interpret date column queries as JSON."""
     if query:
@@ -100,3 +97,10 @@ def parse_timestamp_query(query, schema):
             }
 
     return query
+
+
+def safe_parse_date_to_unix_time(date):
+    if isinstance(date, datetime):
+        date = parse_date_to_unix_time(date)
+
+    return date

--- a/bamboo/lib/utils.py
+++ b/bamboo/lib/utils.py
@@ -10,6 +10,7 @@ def flatten(list_):
 
 
 def combine_dicts(*dicts):
+    """Combine dicts with keys in later dicts taking precedence."""
     return dict(chain(*[_dict.iteritems() for _dict in dicts]))
 
 

--- a/bamboo/models/abstract_model.py
+++ b/bamboo/models/abstract_model.py
@@ -21,8 +21,6 @@ class AbstractModel(object):
 
     DB_READ_BATCH_SIZE = 1000
     DB_SAVE_BATCH_SIZE = 2000
-    DELETED_AT = '-1'  # keys get replicated, we encode as non-generable
-                       # numerics
     ERROR_MESSAGE = 'error_message'
     GROUP_DELIMITER = ','  # delimiter when passing multiple groups as a string
     MIN_BATCH_SIZE = 50
@@ -86,27 +84,17 @@ class AbstractModel(object):
         return model.save(*args)
 
     @classmethod
-    def find(cls, query_args, as_dict=False, as_cursor=False,
-             include_deleted=False):
+    def find(cls, query_args, as_dict=False, as_cursor=False):
         """An interface to MongoDB's find functionality.
 
         :param query_args: An optional QueryArgs to hold the query arguments.
         :param as_cursor: If True, return the cursor.
         :param as_dict: If True, return dicts and not model instances.
-        :param include_deleted: If True, return delete records, default False.
 
         :returns: A list of dicts or model instances for each row returned.
         """
-        query = query_args.query
-
-        if not include_deleted:
-            query[cls.DELETED_AT] = 0
-
-        # exclude deleted at column
-        select = query_args.select or {cls.DELETED_AT: 0}
-
-        cursor = cls.collection.find(query,
-                                     select,
+        cursor = cls.collection.find(query_args.query,
+                                     query_args.select,
                                      sort=query_args.order_by,
                                      limit=query_args.limit)
 
@@ -128,8 +116,6 @@ class AbstractModel(object):
         :returns: A model instance of the row returned for this query and
             select.
         """
-        # exclude deleted at column
-        select = select or {cls.DELETED_AT: 0}
         record = cls.collection.find_one(query, select)
 
         return record if as_dict else cls(record)
@@ -187,12 +173,7 @@ class AbstractModel(object):
 
         :returns: The record passed in.
         """
-        # Set deleted at to False to avoid using poorly indexable $exists
-        # operator in find
-        record[self.DELETED_AT] = 0
-
         self.collection.insert(record)
-        record.pop(self.DELETED_AT)
         self.record = record
 
         return self

--- a/bamboo/models/observation.py
+++ b/bamboo/models/observation.py
@@ -4,10 +4,10 @@ from pandas import concat
 from pymongo.errors import AutoReconnect
 
 from bamboo.core.frame import BambooFrame, DATASET_ID, INDEX
-from bamboo.lib.datetools import parse_timestamp_query
+from bamboo.lib.datetools import now, parse_timestamp_query
 from bamboo.lib.mongo import MONGO_ID, MONGO_ID_ENCODED
 from bamboo.lib.query_args import QueryArgs
-from bamboo.lib.utils import invert_dict, replace_keys
+from bamboo.lib.utils import combine_dicts, invert_dict, replace_keys
 from bamboo.models.abstract_model import AbstractModel
 
 
@@ -51,7 +51,7 @@ class Observation(AbstractModel):
                  DATASET_ID: dataset.dataset_id}
         query = cls.encode(query, dataset=dataset)
 
-        super(cls, cls()).delete(query)
+        cls.__soft_delete(query)
 
     @classmethod
     def delete_all(cls, dataset, query=None):
@@ -110,10 +110,12 @@ class Observation(AbstractModel):
         return invert_dict(cls.encoding(dataset))
 
     @classmethod
-    def find(cls, dataset, query_args=None, as_cursor=False):
+    def find(cls, dataset, query_args=None, as_cursor=False,
+             include_deleted=False):
         """Return observation rows matching parameters.
 
         :param dataset: Dataset to return rows for.
+        :param include_deleted: If True, return delete records, default False.
         :param query_args: An optional QueryArgs to hold the query arguments.
 
         :raises: `JSONError` if the query could not be parsed.
@@ -130,7 +132,8 @@ class Observation(AbstractModel):
 
         distinct = query_args.distinct
         records = super(cls, cls).find(query_args, as_dict=True,
-                                       as_cursor=(as_cursor or distinct))
+                                       as_cursor=(as_cursor or distinct),
+                                       include_deleted=include_deleted)
 
         return records.distinct(encoding.get(distinct, distinct)) if distinct\
             else records
@@ -206,9 +209,13 @@ class Observation(AbstractModel):
         :param dex: The index of the row to update.
         :param record: The dictionary to update the row with.
         """
-        observation = cls.find_one(dataset, index, decode=False)
+        previous_record = cls.find_one(dataset, index).record
+        previous_record.pop('_id')
+        record = combine_dicts(previous_record, record)
         record = cls.encode(record, dataset=dataset)
-        super(cls, observation).update(record)
+
+        cls.delete(dataset, index)
+        super(cls, cls()).save(record)
 
     @classmethod
     def batch_read_dframe_from_cursor(cls, dataset, observations, distinct,
@@ -313,8 +320,20 @@ class Observation(AbstractModel):
 
     @classmethod
     def __encode_records(cls, dframe, encoding):
-        return [replace_keys(row.to_dict(), encoding) for (_, row)
-                in dframe.iterrows()]
+        return [cls.__encode_record(row.to_dict(), encoding)
+                for (_, row) in dframe.iterrows()]
+
+    @classmethod
+    def __encode_record(cls, row, encoding):
+        encoded = replace_keys(row, encoding)
+        encoded[cls.DELETED_AT] = 0
+
+        return encoded
+
+    @classmethod
+    def __soft_delete(cls, query):
+        cls.collection.update(query,
+                              {'$set': {cls.DELETED_AT: now().isoformat()}})
 
     @classmethod
     def __store_encoding(cls, dataset, encoding):

--- a/bamboo/tests/controllers/test_datasets.py
+++ b/bamboo/tests/controllers/test_datasets.py
@@ -8,6 +8,7 @@ from mock import patch
 import simplejson as json
 
 from bamboo.controllers.datasets import Datasets
+from bamboo.lib.datetools import now
 from bamboo.lib.query_args import QueryArgs
 from bamboo.lib.schema_builder import CARDINALITY, DATETIME, OLAP_TYPE,\
     SIMPLETYPE
@@ -399,13 +400,13 @@ class TestDatasets(TestAbstractDatasets):
 
     def test_show_with_date_query(self):
         query = {
-            'submit_date': {'$lt': mktime(datetime.now().timetuple())}
+            'submit_date': {'$lt': mktime(now().timetuple())}
         }
         self.__test_get_with_query_or_select(
             query=json.dumps(query),
             num_results=self.NUM_ROWS)
         query = {
-            'submit_date': {'$gt': mktime(datetime.now().timetuple())}
+            'submit_date': {'$gt': mktime(now().timetuple())}
         }
         self.__test_get_with_query_or_select(
             query=json.dumps(query),

--- a/bamboo/tests/core/test_calculations.py
+++ b/bamboo/tests/core/test_calculations.py
@@ -1,8 +1,7 @@
-from datetime import datetime
-
 import numpy as np
 
 from bamboo.lib.datetools import parse_date_to_unix_time
+from bamboo.lib.datetools import now
 from bamboo.models.dataset import Dataset
 from bamboo.tests.core.test_calculator import TestCalculator
 
@@ -126,8 +125,7 @@ class TestCalculations(TestCalculator):
                 places = self.places
 
                 if dynamic:
-                    now = datetime.now()
-                    stored = parse_date_to_unix_time(now) -\
+                    stored = parse_date_to_unix_time(now()) -\
                         parse_date_to_unix_time(row['submit_date'])
                     # large approximate window for time compares
                     places = 2

--- a/bamboo/tests/models/test_dataset.py
+++ b/bamboo/tests/models/test_dataset.py
@@ -27,8 +27,14 @@ class TestDataset(TestBase):
             rows = Dataset.find(self.test_dataset_ids[dataset_name])
 
             self.assertEqual(record, rows[0].record)
-            self.assertEqual(record, Dataset.find_one(
-                             self.test_dataset_ids[dataset_name]).record)
+
+    def test_find_one(self):
+        for dataset_name in self.TEST_DATASETS:
+            dataset = Dataset.create(self.test_dataset_ids[dataset_name])
+            record = dataset.record
+            row = Dataset.find_one(self.test_dataset_ids[dataset_name])
+
+            self.assertEqual(record, row.record)
 
     def test_create(self):
         for dataset_name in self.TEST_DATASETS:

--- a/docs/basic_commands.rst
+++ b/docs/basic_commands.rst
@@ -11,13 +11,6 @@ Basic Commands
 
     [*SIC*] all spelling errors in the example dataset.
 
-Check the *bamboo* version
---------------------------
-
-.. code-block:: sh
-
-    curl http://bamboo.io/version
-
 Storing data in *bamboo*
 ------------------------
 
@@ -884,3 +877,10 @@ Linked dataset are the same as any other dataset.
             "sum_of_amount": 4.0
         }
     ]
+
+Check the *bamboo* version
+--------------------------
+
+.. code-block:: sh
+
+    curl http://bamboo.io/version

--- a/scripts/db/migrate_to_encoded.py
+++ b/scripts/db/migrate_to_encoded.py
@@ -10,6 +10,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('-d', '--dataset', help='The dataset ID to migrate')
     args = parser.parse_args()
+    main()
 
 
 def main():
@@ -17,6 +18,3 @@ def main():
 
     dataset = Dataset(url=dataset_url)
     print dataset.id
-
-
-main()

--- a/scripts/db/migrations/001_observations_add_deleted_at.py
+++ b/scripts/db/migrations/001_observations_add_deleted_at.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+import os
+import sys
+sys.path.append(os.getcwd())
+
+from bamboo.models.observation import Observation
+
+
+def migrate():
+    observation = Observation
+    record = {Observation.DELETED_AT: 0}
+    observation.collection.update({}, {'$set': record}, multi=True)
+
+
+if __name__ == '__main__':
+    migrate()

--- a/scripts/db/mongo_index.py
+++ b/scripts/db/mongo_index.py
@@ -8,16 +8,17 @@ from pymongo import ASCENDING
 
 from bamboo.config.db import Database
 from bamboo.core.frame import DATASET_ID
-from bamboo.models.abstract_model import AbstractModel
 from bamboo.models.observation import Observation
 
 # The encoded dataset_id will be set to '0'.
 ENCODED_DATASET_ID = '0'
 
+
 def bamboo_index(collection, key):
     ensure_index = collection.__getattribute__('ensure_index')
     ensure_index([(key, ASCENDING)])
-    ensure_index([(key, ASCENDING), (AbstractModel.DELETED_AT, ASCENDING)])
+    ensure_index([(key, ASCENDING), (Observation.DELETED_AT, ASCENDING)])
+
 
 def ensure_indexing():
     """Ensure that bamboo models are indexed."""
@@ -31,7 +32,7 @@ def ensure_indexing():
     # indices
     bamboo_index(datasets, DATASET_ID)
     bamboo_index(observations, ENCODED_DATASET_ID)
-    bamboo_index(observations, Observations.ENCODING_DATASET_ID)
+    bamboo_index(observations, Observation.ENCODING_DATASET_ID)
     bamboo_index(calculations, DATASET_ID)
 
 

--- a/scripts/db/mongo_index.py
+++ b/scripts/db/mongo_index.py
@@ -11,19 +11,28 @@ from bamboo.core.frame import DATASET_ID
 from bamboo.models.abstract_model import AbstractModel
 from bamboo.models.observation import Observation
 
+# The encoded dataset_id will be set to '0'.
+ENCODED_DATASET_ID = '0'
+
+def bamboo_index(collection, key):
+    ensure_index = collection.__getattribute__('ensure_index')
+    ensure_index([(key, ASCENDING)])
+    ensure_index([(key, ASCENDING), (AbstractModel.DELETED_AT, ASCENDING)])
 
 def ensure_indexing():
     """Ensure that bamboo models are indexed."""
     db = Database.db()
+
+    # collections
     calculations = db.calculations
     datasets = db.datasets
     observations = db.observations
-    datasets.ensure_index([(DATASET_ID, ASCENDING)])
-    # The encoded dataset_id will be set to '0'.
-    observations.ensure_index(
-        [('0', ASCENDING), (AbstractModel.DELETED_AT, ASCENDING)])
-    observations.ensure_index([(Observation.ENCODING_DATASET_ID, ASCENDING)])
-    calculations.ensure_index([(DATASET_ID, ASCENDING)])
+
+    # indices
+    bamboo_index(datasets, DATASET_ID)
+    bamboo_index(observations, ENCODED_DATASET_ID)
+    bamboo_index(observations, Observations.ENCODING_DATASET_ID)
+    bamboo_index(calculations, DATASET_ID)
 
 
 if __name__ == '__main__':

--- a/scripts/db/mongo_index.py
+++ b/scripts/db/mongo_index.py
@@ -8,6 +8,7 @@ from pymongo import ASCENDING
 
 from bamboo.config.db import Database
 from bamboo.core.frame import DATASET_ID
+from bamboo.models.abstract_model import AbstractModel
 from bamboo.models.observation import Observation
 
 
@@ -19,10 +20,11 @@ def ensure_indexing():
     observations = db.observations
     datasets.ensure_index([(DATASET_ID, ASCENDING)])
     # The encoded dataset_id will be set to '0'.
-    observations.ensure_index([("0", ASCENDING)])
+    observations.ensure_index(
+        [('0', ASCENDING), (AbstractModel.DELETED_AT, ASCENDING)])
     observations.ensure_index([(Observation.ENCODING_DATASET_ID, ASCENDING)])
     calculations.ensure_index([(DATASET_ID, ASCENDING)])
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     ensure_indexing()


### PR DESCRIPTION
IMPORT BEFORE DEPLOY NOTE: This PR requires a data migration, run:

``` sh
python scripts/db/migrations/001_observations_add_deleted_at
```

which adds `{'deleted_at': 0}` to all existing observations.

First round of keeping historical data, currently on delete or update of a dataset row the data is removed from the collection or overwritten.

With this change, on deletion, the key `deleted_at` is set to the current time.  On update the same key is set on the existing record and a new record is created with the updated row.

On `find` any rows with `deleted_at` not set to 0 are ignored by default (MongoDB docs say this is faster than only having `deleted_at` for deleted rows and then using the `$exists` operator).

Currently, there is no client-accessible interface for accessing deleted rows.
